### PR TITLE
Add a `repository` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
   },
   "bin": {
     "rollupbabel": "./bin/rollup"
-  }
+  },
+  "repository": "rollup/rollup-babel"
 }


### PR DESCRIPTION
Otherwise there’s no link from http://npm.im/rollup-babel to the repo.
